### PR TITLE
11 add quiz category filter api

### DIFF
--- a/quizapp-backend/src/main/java/com/example/quizapp/controller/QuizController.java
+++ b/quizapp-backend/src/main/java/com/example/quizapp/controller/QuizController.java
@@ -18,15 +18,25 @@ public class QuizController {
     }
 
     // すべての質問を取得
-    @GetMapping
-    public List<Quiz> getAllQuizzes() {
-        return quizRepository.findAll();
-    }
+    // @GetMapping
+    // public List<Quiz> getAllQuizzes() {
+    //     return quizRepository.findAll();
+    // }
 
     // 新しい質問を追加
     @PostMapping
     public ResponseEntity<Quiz> createQuiz(@RequestBody Quiz quiz) {
         Quiz savedQuiz = quizRepository.save(quiz);
         return ResponseEntity.ok(savedQuiz);
+    }
+
+    // 絞り込み用のAPIを追加
+    @GetMapping
+    public List<Quiz> getQuizzes(@RequestParam(required = false) String category) {
+        if (category != null && !category.isEmpty()) {
+            return quizRepository.findByCategory(category);
+        } else {
+            return quizRepository.findAll();
+        }
     }
 }

--- a/quizapp-backend/src/main/java/com/example/quizapp/entity/Quiz.java
+++ b/quizapp-backend/src/main/java/com/example/quizapp/entity/Quiz.java
@@ -35,4 +35,7 @@ public class Quiz {
 
     @Column
     private String explanation;
+
+    @Column(nullable = false) // カテゴリを必須したくない時はnullable = trueにする
+    private String category = "未分類";
 }

--- a/quizapp-backend/src/main/java/com/example/quizapp/repository/QuizRepository.java
+++ b/quizapp-backend/src/main/java/com/example/quizapp/repository/QuizRepository.java
@@ -4,6 +4,10 @@ import com.example.quizapp.entity.Quiz;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface QuizRepository extends JpaRepository<Quiz, Long> {
+  // カテゴリでクイズを検索するメソッド
+  List<Quiz> findByCategory(String category);
 }

--- a/quizapp-frontend/src/api.ts
+++ b/quizapp-frontend/src/api.ts
@@ -23,6 +23,18 @@ export const fetchQuizzes = async (): Promise<Quiz[]> => {
 };
 
 /**
+ * カテゴリー毎のクイズを取得する
+ */
+export const fetchQuizzesByCategory = async (
+  category: string
+): Promise<Quiz[]> => {
+  const response = await axios.get<Quiz[]>(
+    `/api/quizzes?category=${encodeURIComponent(category)}`
+  );
+  return response.data;
+};
+
+/**
  * 新しいクイズを作成する
  * @param quiz - クイズ情報。id は自動生成されるので含めない
  */

--- a/quizapp-frontend/src/api.ts
+++ b/quizapp-frontend/src/api.ts
@@ -28,9 +28,7 @@ export const fetchQuizzes = async (): Promise<Quiz[]> => {
 export const fetchQuizzesByCategory = async (
   category: string
 ): Promise<Quiz[]> => {
-  const response = await axios.get<Quiz[]>(
-    `/api/quizzes?category=${encodeURIComponent(category)}`
-  );
+  const response = await axios.get<Quiz[]>(API_URL, { params: { category } });
   return response.data;
 };
 

--- a/quizapp-frontend/src/components/Home.vue
+++ b/quizapp-frontend/src/components/Home.vue
@@ -2,7 +2,13 @@
   <div class="home-container">
     <h1 class="title">まなぶん！おかねクイズ</h1>
     <p class="subtitle">お金のこと、楽しく学ぼう！</p>
-    <button @click="startQuiz" class="start-button">クイズをはじめる</button>
+    <p class="category-button">
+      <button @click="startQuiz('買い物')">買い物</button>
+      <button @click="startQuiz('貯金')">貯金</button>
+    </p>
+    <button @click="startQuiz('未分類')" class="start-button">
+      クイズをはじめる
+    </button>
   </div>
 </template>
 
@@ -10,8 +16,8 @@
 import { useRouter } from "vue-router";
 const router = useRouter();
 
-const startQuiz = () => {
-  router.push("/quiz");
+const startQuiz = (category: string) => {
+  router.push({ path: "/quiz", query: { category } });
 };
 </script>
 


### PR DESCRIPTION
## 📝 概要（What / Why）
<!-- このプルリクエストで何を変更・追加したのか、その目的は何かを簡潔に記載してください -->
クイズをカテゴリーして取得できる
クイズの量が増やすときにカテゴリーでフィルタできると便利で学習効率をあげる狙い

## ✅ 変更内容（Changes）
- [x] 機能追加: カテゴリー別クイズ表示
- [ ] バグ修正: xxx
- [ ] UI改善: xxx
- [ ] ドキュメント更新: xxx
- [ ] その他（具体的に）:

## 🧪 テスト内容（How to Test）
<!-- 動作確認した内容・方法・手順などを記載してください -->

## 🖥 スクリーンショット（UI変更があれば）
<!-- Before / After の画像があるとレビューしやすくなります -->
![image](https://github.com/user-attachments/assets/11f111c5-f439-4e83-a536-95a3f438bfc2)
![image](https://github.com/user-attachments/assets/099cddc8-ac1b-42b2-936b-ec50300e4aad)
![Screenshot 2025-03-23 22 23 26](https://github.com/user-attachments/assets/88f8d46b-aeae-480d-a63b-d01709bcd483)
![image](https://github.com/user-attachments/assets/a3d273d8-e0ec-4cca-9573-755793f53b51)


## 🔗 関連するIssue
<!-- 関連するIssueがあれば記載してください -->
テーブルにカテゴリーのカラムを追加して、フィルターできる機能を実装しよう #11

## ⚠️ 注意点
<!-- レビュー時に見てほしいポイント、影響範囲、マイグレーションの有無など -->

## 🤖 補足（任意）
<!-- デプロイ手順、参考リンク、学びポイントなど -->
